### PR TITLE
Problem: can't install from fork directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "babel source --out-dir distribution",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "npm run build"
+    "gulp": "gulp",
+    "prepare": "npm run build && npm run gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Solution: add a prepare step that will run babel and gulp when installing from git repo.  This should also run prepublish.

Side note: This means the build directory probably doesn't need to be under source control anymore since it should get built on npm install and publish :)